### PR TITLE
Use cut instead of ERE

### DIFF
--- a/lib/facter/ca_exp_date.rb
+++ b/lib/facter/ca_exp_date.rb
@@ -3,6 +3,6 @@ Facter.add(:ca_exp_date) do
     File.exist? '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
   end
   setcode do
-    Facter::Core::Execution.execute('/opt/puppetlabs/puppet/bin/openssl x509 -enddate -noout -in /etc/puppetlabs/puppet/ssl/certs/ca.pem | sed -r \'s/.{9}//\'')
+    Facter::Core::Execution.execute('/opt/puppetlabs/puppet/bin/openssl x509 -enddate -noout -in /etc/puppetlabs/puppet/ssl/certs/ca.pem | cut -f2- -d "="')
   end
 end


### PR DESCRIPTION
We should be using either `cut` or Bash parameter expansion for better compatibility over a `sed` ERE.  `cut` looks like it's easier to use inside of Facter execution.